### PR TITLE
Resolver support by developer name and sobjecttype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 .idea
 IlluminatedCloud
 /temp
+package-lock.json
+package.json
+/node_modules

--- a/force-di/main/classes/di_Binding.cls
+++ b/force-di/main/classes/di_Binding.cls
@@ -120,9 +120,6 @@ public abstract class di_Binding implements Comparable {
         private String developerName;
         private SObjectType bindingObject;
         
-        // Determine if all filtering params are required to resolve bindings
-        private Boolean isResolvingByAllFilteringParams = false;
- 
         // Modules used by the Resolver to discover bindings
         private List<di_Module> modules = null;
         // Discovered bindings via the modules supplied to this resolver
@@ -151,14 +148,6 @@ public abstract class di_Binding implements Comparable {
         public Resolver add(di_Module module) {
             modules.add(module);
             bindings = null; // Force reload of bindings
-            return this;
-        }
-
-        /**
-         * Must resolve using filtering params 
-         */
-        public Resolver resolveUsingAllFilteringParams() {
-            this.isResolvingByAllFilteringParams = true;
             return this;
         }
 
@@ -195,16 +184,18 @@ public abstract class di_Binding implements Comparable {
             // Filter bindings returned by preconfigured criteria
             List<di_Binding> matchedBindings = new List<di_Binding>();
             for (di_Binding bind : bindings) {
-                if ( this.isResolvingByAllFilteringParams ) 
+                // if both filtering parameters were specified
+                if ( String.isNotBlank(this.developerName) && this.bindingObject != null ) 
                 {
-                    if ( String.isNotBlank(this.developerName) && String.isNotBlank(bind.DeveloperName)
-                        && bind.DeveloperName.equalsIgnoreCase(developerName)
-                        && bindingObject != null && bind.BindingObject == bindingObject )
+                    // then require both match for the binding to be included.
+                    if ( this.developerName.equalsIgnoreCase( bind.DeveloperName )
+                        && this.bindingObject == bind.BindingObject )
                     {
                         matchedBindings.add(bind);
                     }
                 }
                 else {
+                    // else match on any of the available filtering parameters
                     if (String.isNotBlank(this.developerName) && String.isNotBlank(bind.DeveloperName)
                             && bind.DeveloperName.equalsIgnoreCase(developerName)) 
                     {

--- a/force-di/main/classes/di_Binding.cls
+++ b/force-di/main/classes/di_Binding.cls
@@ -119,6 +119,10 @@ public abstract class di_Binding implements Comparable {
         // Filter params for resolving bindings
         private String developerName;
         private SObjectType bindingObject;
+        
+        // Determine if all filtering params are required to resolve bindings
+        private Boolean isResolvingByAllFilteringParams = false;
+ 
         // Modules used by the Resolver to discover bindings
         private List<di_Module> modules = null;
         // Discovered bindings via the modules supplied to this resolver
@@ -147,6 +151,14 @@ public abstract class di_Binding implements Comparable {
         public Resolver add(di_Module module) {
             modules.add(module);
             bindings = null; // Force reload of bindings
+            return this;
+        }
+
+        /**
+         * Must resolve using filtering params 
+         */
+        public Resolver resolveUsingAllFilteringParams() {
+            this.isResolvingByAllFilteringParams = true;
             return this;
         }
 
@@ -182,11 +194,26 @@ public abstract class di_Binding implements Comparable {
             }
             // Filter bindings returned by preconfigured criteria
             List<di_Binding> matchedBindings = new List<di_Binding>();
-            for(di_Binding bind : bindings) {
-                if(developerName!=null && bind.DeveloperName!=null && bind.DeveloperName.equalsIgnoreCase(developerName)) {
-                    matchedBindings.add(bind);
-                } else if (bindingObject!=null && bind.BindingObject == bindingObject) {
-                    matchedBindings.add(bind);
+            for (di_Binding bind : bindings) {
+                if ( this.isResolvingByAllFilteringParams ) 
+                {
+                    if ( String.isNotBlank(this.developerName) && String.isNotBlank(bind.DeveloperName)
+                        && bind.DeveloperName.equalsIgnoreCase(developerName)
+                        && bindingObject != null && bind.BindingObject == bindingObject )
+                    {
+                        matchedBindings.add(bind);
+                    }
+                }
+                else {
+                    if (String.isNotBlank(this.developerName) && String.isNotBlank(bind.DeveloperName)
+                            && bind.DeveloperName.equalsIgnoreCase(developerName)) 
+                    {
+                        matchedBindings.add(bind);
+                    } 
+                    else if (bindingObject != null && bind.BindingObject == bindingObject) 
+                    {
+                        matchedBindings.add(bind);
+                    }
                 }
             }
             this.developerName = null;

--- a/force-di/main/classes/di_Binding.cls
+++ b/force-di/main/classes/di_Binding.cls
@@ -173,10 +173,10 @@ public abstract class di_Binding implements Comparable {
          **/
         public List<di_Binding> get() {
             // Late resolve bindings to allow runtime module injection via set and add methods
-            if(bindings==null) {
+            if (bindings==null) {
                 // Ask each module to configure and aggregate the resulting bindings
                 bindings = new List<di_Binding>();
-                for(di_Module module : modules) {
+                for (di_Module module : modules) {
                     module.configure();
                     bindings.addAll(module.getBindings());
                 }
@@ -196,12 +196,12 @@ public abstract class di_Binding implements Comparable {
                 }
                 else {
                     // else match on any of the available filtering parameters
-                    if (String.isNotBlank(this.developerName) && String.isNotBlank(bind.DeveloperName)
-                            && bind.DeveloperName.equalsIgnoreCase(developerName)) 
+                    if ( String.isNotBlank(bind.DeveloperName)
+                        && bind.DeveloperName.equalsIgnoreCase(this.developerName)) 
                     {
                         matchedBindings.add(bind);
                     } 
-                    else if (bindingObject != null && bind.BindingObject == bindingObject) 
+                    else if (this.bindingObject != null && bind.BindingObject == this.bindingObject) 
                     {
                         matchedBindings.add(bind);
                     }

--- a/force-di/main/classes/di_Injector.cls
+++ b/force-di/main/classes/di_Injector.cls
@@ -119,8 +119,7 @@ public class di_Injector {
             throw new InjectorException('Request for Binding cannot take "bindingSObjectType" parameter of null');
         }
 
-        List<di_Binding> bindings = Bindings.resolveUsingAllFilteringParams()
-                                            .bySObject( bindingSObjectType )
+        List<di_Binding> bindings = Bindings.bySObject( bindingSObjectType )
                                             .byName( developerName.toLowerCase().trim() )
                                             .get();
 

--- a/force-di/main/classes/di_Injector.cls
+++ b/force-di/main/classes/di_Injector.cls
@@ -92,6 +92,46 @@ public class di_Injector {
     }
 
     /**
+     * Creates an instance of the object configured for the named binding and the binding SObjectType
+     **/
+    public Object getInstance(Type developerNameByType, Schema.SObjectType bindingSObjectType) {
+        return getInstance(developerNameByType, bindingSObjectType, null);
+    }
+
+    /**
+     * Creates an instance of the object configured for the named binding and the binding SObjectType
+     *   (if params is specified, implicitly uses the Provider interface)
+     **/
+    public Object getInstance(Type developerNameByType, Schema.SObjectType bindingSObjectType, Object params) {
+        return getInstance(developerNameByType == null ? null : developerNameByType.getName().toLowerCase(), bindingSObjectType, params);
+    }
+
+    /**
+     * Creates an instance of the object configured for the named binding and the binding SObjectType
+     *   (if params is specified, implicitly uses the Provider interface)
+     **/
+    public Object getInstance(String developerName, Schema.SObjectType bindingSObjectType, Object params) {
+        if ( String.isBlank(developerName) ) {
+            throw new InjectorException('Request for Binding cannot take "developerName" parameter of null');
+        }
+
+        if ( bindingSObjectType == null ) {
+            throw new InjectorException('Request for Binding cannot take "bindingSObjectType" parameter of null');
+        }
+
+        List<di_Binding> bindings = Bindings.resolveUsingAllFilteringParams()
+                                            .bySObject( bindingSObjectType )
+                                            .byName( developerName.toLowerCase().trim() )
+                                            .get();
+
+        if ( bindings == null || bindings.isEmpty() ) {
+            throw new InjectorException('Binding for "' + developerName + '" and SObjectType "' + bindingSObjectType + '" not found');
+        }
+        return bindings[0].getInstance(params);
+
+    }
+
+    /**
      * A Module that loads bindings configured via the Binding__mdt object
      **/
     private class CustomMetadataModule extends di_Module {


### PR DESCRIPTION
Changes would allow for scenarios like ...
`di_Injector.Org.getInstance( IApplicationSObjectSelector.class, Account.SObjectType )` 

and they would not be confused by other SObject based bindings like ...
`di_Injector.Org.getInstance( IApplicationSObjectDomain.class, Account.SObjectType )`