### PR TITLE
Replace default binding with object

### DIFF
--- a/force-di/main/classes/di_Binding.cls
+++ b/force-di/main/classes/di_Binding.cls
@@ -167,13 +167,83 @@ public abstract class di_Binding implements Comparable {
             return this;
         }
 
+        /*
+         * Replace an existing binding for test mocking purposes
+         */
+        public Resolver replaceBindingWith( Object mockType )
+        {
+            // system.debug('replaceBindingWith method called');
+            
+            // find existing binding's position in the list.
+            Boolean isMatchFound = false;
+            Integer currentBindingsIndex = -1;
+
+            while ( currentBindingsIndex < this.bindings.size() 
+                    && !isMatchFound ) 
+            {
+                isMatchFound = isBindingMatchByFilteringCriteria( this.bindings[++currentBindingsIndex] );
+            }
+
+            if (isMatchFound)
+            {
+                // system.debug('replaceBindingWith method -- replacing existing binding');
+                this.bindings[currentBindingsIndex] = di_Binding.newInstance(di_Binding.BindingType.Apex, this.developerName, this.bindingObject, null, mockType, null);
+            }
+            
+            // system.debug('replaceBindingWith method finished');
+
+            return this;
+        }
+
+        /*
+         *  Method used to determind if the di_Binding record supplied matches
+         *  the available filtering parameters.
+         *
+         *  @param The current di_Binding from the Resolver's list of bindings to examine
+         *  @return True if the current di_Binding is a match to the filtering critera.
+         */
+        private Boolean isBindingMatchByFilteringCriteria( di_Binding bind )
+        {
+            Boolean isMatch = false;
+            // system.debug('bind == ' + bind);
+            // system.debug('this.developerName == ' + this.developerName);
+            // system.debug('this.bindingObject == ' + this.bindingObject); 
+
+            // if both filtering parameters were specified
+            if ( String.isNotBlank(this.developerName) && this.bindingObject != null ) 
+            {
+                // then require both match for the binding to be included.
+                if ( this.developerName.equalsIgnoreCase( bind.DeveloperName )
+                    && this.bindingObject == bind.BindingObject )
+                {
+                    isMatch = true;
+                }
+            }
+            else {
+                // else match on any of the available filtering parameters
+                if ( String.isNotBlank(bind.DeveloperName)
+                    && bind.DeveloperName.equalsIgnoreCase(this.developerName)) 
+                {
+                    isMatch = true;
+                } 
+                else if (this.bindingObject != null && bind.BindingObject == this.bindingObject) 
+                {
+                    isMatch = true;
+                }
+            }
+            
+            // system.debug('isMatch == ' + isMatch); 
+
+            return isMatch;
+        }
+
         /**
          * Returns a filtered and sorted list of known bindings
          * Priority is given to filtering by DeveloperName if specified
          **/
         public List<di_Binding> get() {
             // Late resolve bindings to allow runtime module injection via set and add methods
-            if (bindings==null) {
+            if (bindings == null) {
                 // Ask each module to configure and aggregate the resulting bindings
                 bindings = new List<di_Binding>();
                 for (di_Module module : modules) {
@@ -184,27 +254,9 @@ public abstract class di_Binding implements Comparable {
             // Filter bindings returned by preconfigured criteria
             List<di_Binding> matchedBindings = new List<di_Binding>();
             for (di_Binding bind : bindings) {
-                // if both filtering parameters were specified
-                if ( String.isNotBlank(this.developerName) && this.bindingObject != null ) 
+                if ( isBindingMatchByFilteringCriteria(bind) )
                 {
-                    // then require both match for the binding to be included.
-                    if ( this.developerName.equalsIgnoreCase( bind.DeveloperName )
-                        && this.bindingObject == bind.BindingObject )
-                    {
-                        matchedBindings.add(bind);
-                    }
-                }
-                else {
-                    // else match on any of the available filtering parameters
-                    if ( String.isNotBlank(bind.DeveloperName)
-                        && bind.DeveloperName.equalsIgnoreCase(this.developerName)) 
-                    {
-                        matchedBindings.add(bind);
-                    } 
-                    else if (this.bindingObject != null && bind.BindingObject == this.bindingObject) 
-                    {
-                        matchedBindings.add(bind);
-                    }
+                    matchedBindings.add(bind);
                 }
             }
             this.developerName = null;

--- a/force-di/main/classes/di_Binding.cls
+++ b/force-di/main/classes/di_Binding.cls
@@ -184,6 +184,9 @@ public abstract class di_Binding implements Comparable {
         {
             // system.debug('replaceBindingWith method called');
 
+            // Late resolve bindings to allow runtime module injection via set and add methods
+            loadBindings();
+
             // find existing binding's position in the list.
             Boolean isMatchFound = false;
             Integer currentBindingsIndex = -1;
@@ -199,7 +202,10 @@ public abstract class di_Binding implements Comparable {
                 // system.debug('replaceBindingWith method -- replacing existing binding');
                 this.bindings[currentBindingsIndex] = di_Binding.newInstance(di_Binding.BindingType.Apex, this.developerName, this.bindingObject, null, mockType, null);
             }
-            
+
+            this.developerName = null;
+            this.bindingObject = null;
+
             // system.debug('replaceBindingWith method finished');
 
             return this;
@@ -214,6 +220,7 @@ public abstract class di_Binding implements Comparable {
          */
         private Boolean isBindingMatchByFilteringCriteria( di_Binding bind )
         {
+            // System.debug('isBindingMatchByFilteringCriteria method called');
             Boolean isMatch = false;
             // system.debug('bind == ' + bind);
             // system.debug('this.developerName == ' + this.developerName);
@@ -247,20 +254,28 @@ public abstract class di_Binding implements Comparable {
             return isMatch;
         }
 
+        private void loadBindings()
+        {
+            if (this.bindings == null) {
+                System.debug('loading bindings');
+                // Ask each module to configure and aggregate the resulting bindings
+                this.bindings = new List<di_Binding>();
+                for (di_Module module : modules) 
+                {
+                    module.configure();
+                    this.bindings.addAll(module.getBindings());
+                }
+            }
+        }
+
         /**
          * Returns a filtered and sorted list of known bindings
          * Priority is given to filtering by DeveloperName if specified
          **/
         public List<di_Binding> get() {
             // Late resolve bindings to allow runtime module injection via set and add methods
-            if (bindings == null) {
-                // Ask each module to configure and aggregate the resulting bindings
-                bindings = new List<di_Binding>();
-                for (di_Module module : modules) {
-                    module.configure();
-                    bindings.addAll(module.getBindings());
-                }
-            }
+            loadBindings();
+
             // Filter bindings returned by preconfigured criteria
             List<di_Binding> matchedBindings = new List<di_Binding>();
             for (di_Binding bind : bindings) {

--- a/force-di/main/classes/di_Binding.cls
+++ b/force-di/main/classes/di_Binding.cls
@@ -153,6 +153,9 @@ public abstract class di_Binding implements Comparable {
 
         /**
          * Resolve by name
+         *
+         *  @param the developerName of the Binding to be used as a filter in the resolving process.
+         *  @return the current di_Binding.Resolver instance
          **/
         public Resolver byName(String developerName) {
             this.developerName = developerName;
@@ -161,19 +164,26 @@ public abstract class di_Binding implements Comparable {
 
         /**
          * Resolve by object type
+         *
+         *  @param the bindingObject to be used as a filter in the resolving process.
+         *  @return the current di_Binding.Resolver instance
          **/
         public Resolver bySObject(SObjectType bindingObject) {
             this.bindingObject = bindingObject;
             return this;
         }
 
-        /*
-         * Replace an existing binding for test mocking purposes
+        /**
+         * Replaces an existing binding for test mocking purposes.  This method is used in conjunction with the filtering
+         * param methods of the di_Binding.Resolver class like "byName(String)" and "bySObject(SObjectType)". 
+         *
+         *  @param mockType - this is the Apex class that replaces the binding that is currently in default list of bindings
+         *  @return the current di_Binding.Resolver instance
          */
         public Resolver replaceBindingWith( Object mockType )
         {
             // system.debug('replaceBindingWith method called');
-            
+
             // find existing binding's position in the list.
             Boolean isMatchFound = false;
             Integer currentBindingsIndex = -1;
@@ -196,7 +206,7 @@ public abstract class di_Binding implements Comparable {
         }
 
         /*
-         *  Method used to determind if the di_Binding record supplied matches
+         *  Method used to determine if the di_Binding record supplied matches
          *  the available filtering parameters.
          *
          *  @param The current di_Binding from the Resolver's list of bindings to examine

--- a/force-di/main/classes/di_Injector.cls
+++ b/force-di/main/classes/di_Injector.cls
@@ -84,11 +84,11 @@ public class di_Injector {
             throw new InjectorException('Request for Binding cannot take "developerName" parameter of null');
         }
 
-        List<di_Binding> bindings = Bindings.byName( developerName.toLowerCase().trim() ).get();
-        if ( bindings == null || bindings.isEmpty() ) {
+        List<di_Binding> bindingsFound = this.Bindings.byName( developerName.toLowerCase().trim() ).get();
+        if ( bindingsFound == null || bindingsFound.isEmpty() ) {
             throw new InjectorException('Binding for "' + developerName + '" not found');
         }
-        return bindings[0].getInstance(params);
+        return bindingsFound[0].getInstance(params);
     }
 
     /**
@@ -119,14 +119,14 @@ public class di_Injector {
             throw new InjectorException('Request for Binding cannot take "bindingSObjectType" parameter of null');
         }
 
-        List<di_Binding> bindings = Bindings.bySObject( bindingSObjectType )
+        List<di_Binding> bindingsFound = this.Bindings.bySObject( bindingSObjectType )
                                             .byName( developerName.toLowerCase().trim() )
                                             .get();
 
-        if ( bindings == null || bindings.isEmpty() ) {
+        if ( bindingsFound == null || bindingsFound.isEmpty() ) {
             throw new InjectorException('Binding for "' + developerName + '" and SObjectType "' + bindingSObjectType + '" not found');
         }
-        return bindings[0].getInstance(params);
+        return bindingsFound[0].getInstance(params);
 
     }
 


### PR DESCRIPTION
New feature to support the replacement of default bindings for the purpose of mocking.

Example usage
```java
private void setMock(IApplicationSObjectSelector selectorInstance)
{
    di_Injector.Org.Bindings.byName( IApplicationSObjectSelector.class.getName() )
            .bySObject( selectorInstance.sObjectType() )
            .replaceBindingWith( selectorInstance );
} 
```
