### PR TITLE
fixes #31

### DIFF
--- a/force-di/main/classes/di_Injector.cls
+++ b/force-di/main/classes/di_Injector.cls
@@ -139,14 +139,14 @@ public class di_Injector {
             // TODO: Support Namespace
             for(di_Binding__mdt bindingConfig :
                 [select QualifiedAPIName, DeveloperName, NamespacePrefix,
-                        Type__c, To__c, BindingObject__c, BindingSequence__c
+                        Type__c, To__c, BindingObject__c, BindingObject__r.QualifiedApiName, BindingSequence__c
                     from di_Binding__mdt]) {
                 bind(bindingConfig.DeveloperName);
                 type(bindingConfig.Type__c);
                 if(String.isNotBlank(bindingConfig.BindingObject__c)) {
-                    Schema.DescribeSobjectResult[] results = Schema.describeSObjects(new String[] { bindingConfig.BindingObject__c.toLowerCase().trim() });
+                    Schema.DescribeSobjectResult[] results = Schema.describeSObjects(new String[] { bindingConfig.BindingObject__r.QualifiedApiName.toLowerCase().trim() });
                     if(results.size() != 1) {
-                        throw new InjectorException('Failed to find SObject ' + bindingConfig.BindingObject__c + ' referened by binding ' + bindingConfig.DeveloperName );
+                        throw new InjectorException('Failed to find SObject ' + bindingConfig.BindingObject__r.QualifiedApiName + ' referened by binding ' + bindingConfig.DeveloperName );
                     }
                     bind(results[0].getSObjectType());
                 }


### PR DESCRIPTION
Changes made:
- because of an odd platform behavior, we need to query the
    BindingObject__r.QualifiedApiName instead of the BindingObject__c.
    This is because if you specify a custom SObject, the SObject metadata
    ID is returned instead of the qualified API name.  For standard
    SObjects, the BindingObject__c value returned is the qualified API
    name.  It is wierd.