### PR TITLE
Removing references to package name and version

### DIFF
--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -2,10 +2,7 @@
     "packageDirectories": [
         {
             "path": "force-di",
-            "default": true,
-            "package": "force-di",
-            "versionName": "ver 0.1",
-            "versionNumber": "0.1.0.NEXT"
+            "default": true
         },
         {
             "path": "force-di-trigger-demo",
@@ -26,12 +23,5 @@
     ],
     "namespace": "",
     "sfdcLoginUrl": "https://login.salesforce.com",
-    "sourceApiVersion": "44.0",
-    "packageAliases": {
-        "force-di": "0Ho1N000000GmaTSAS",
-        "force-di@0.1.0-1": "04t1N000000Cr1fQAC",
-        "force-di@0.1.0-2": "04t1N000000Cr1zQAC",
-        "force-di@0.1.0-3": "04t1N000000Cr2dQAC",
-        "force-di@0.1.0-4": "04t1N000000Cr7oQAC"
-    }
+    "sourceApiVersion": "44.0"
 }


### PR DESCRIPTION
This will avoid confusion between DevHubs and allow folks
to build their own package versions.