### PR TITLE
Fixes issue #46

### DIFF
--- a/force-di/main/classes/di_PlatformCache.cls
+++ b/force-di/main/classes/di_PlatformCache.cls
@@ -14,7 +14,7 @@ public with sharing class di_PlatformCache
         return instance;
     }
 
-    private di_Configurations__c getConfig()
+    private static di_Configurations__c getConfig()
     {
         di_Configurations__c config = di_Configurations__c.getInstance();
 
@@ -33,7 +33,7 @@ public with sharing class di_PlatformCache
         return getConfig().UsePlatformCacheToStoreBindings__c == null ? false : getConfig().UsePlatformCacheToStoreBindings__c;
     }
 
-    private String getPartitionName()
+    private static String getPartitionName()
     {
         return getConfig().OrgCachePartitionName__c;
     }
@@ -43,7 +43,7 @@ public with sharing class di_PlatformCache
         return 86400; // number of seconds for a 24 hour period
     }
 
-    private Cache.OrgPartition getPartition()
+    private static Cache.OrgPartition getPartition()
     {
         return Cache.Org.getPartition(getPartitionName());
     }
@@ -54,12 +54,30 @@ public with sharing class di_PlatformCache
     {
         if ( cacheKeyIndexMap.isEmpty() )
         {
-            cacheKeyIndexMap = (Map<String, Map<Schema.SObjectType, Set<String>>>) getPartition().get( getKeyIndexName() );
+            try {
+                cacheKeyIndexMap = (Map<String, Map<Schema.SObjectType, Set<String>>>) getPartition().get( getKeyIndexName() );
+            }
+            catch (Cache.Org.OrgCacheException ex) {
+                // this indicates a potentially corrupt cache, so clear the map and let it rebuild
+                cacheKeyIndexMap = null;
+            }
 
             if ( cacheKeyIndexMap == null )
             {
                 cacheKeyIndexMap = new Map<String, Map<Schema.SObjectType, Set<String>>>();
-            } 
+            }
+            
+            /*
+            for(String key : cacheKeyIndexMap.keySet()) {
+                System.debug('Cache Key => ' + key);
+                for (SObjectType subkey : cacheKeyIndexMap.get(key).keySet()) {
+                    System.debug('Cache Key Index => ' + subkey);
+                    for(String item : cacheKeyIndexMap.get(key).get(subkey)) {
+                        System.debug('Cache Key Index Item => ' + item);
+                    }
+                }
+            }
+            */
         }
 
         return cacheKeyIndexMap;
@@ -89,16 +107,21 @@ public with sharing class di_PlatformCache
         pushCacheKeyIndexMapToCache();
     }
 
+    private static Map<String, String> generatedKeyNames = new Map<String, String>();
+
     private String constructKeyName( Schema.SObjectType bindingSObjectType, String developerName )
     {
-        return String.valueOf( 
-                    Math.abs( 
-                        ( 
-                            ( ( bindingSObjectType != null ) ? bindingSObjectType.getDescribe().getName().toLowerCase().replaceAll('__','') : '' ) 
-                            + ( String.isBlank(developerName) ? '' : developerName.toLowerCase().trim() )
-                        ).hashcode() 
-                    ) 
-                );
+        String key = ( ( bindingSObjectType != null ) ? bindingSObjectType.getDescribe().getName().toLowerCase().replaceAll('__','') : '' ) 
+                            + ( String.isBlank(developerName) ? '' : developerName.toLowerCase().trim() );
+
+        // put generated hash into a map on first pass, so that we do not perform hashcode() operation more than once per "key"
+        // hashcode() is a more expensive operation than map.get()
+        if (generatedKeyNames.containsKey(key)) { return generatedKeyNames.get(key); }
+
+        String hash = String.valueOf( Math.abs( ( key ).hashcode() ) );
+        //System.debug('Creating Hash For => ' + developerName + ' && ' + bindingSObjectType + ' := ' + hash);
+        generatedKeyNames.put(key, hash);
+        return hash;
     }
 
     private String getKeyName( String developerName, Schema.SObjectType bindingSObjectType)
@@ -120,20 +143,22 @@ public with sharing class di_PlatformCache
     {
         if ( isStoringBindingInPlatformCache() )
         {
+            String theKeyName = getKeyName(binding);
             // add the binding to the platform cache directly
-            getPartition().put(getKeyName(binding), binding, getPartitionTTL(), Cache.Visibility.ALL, false);
+            getPartition().put(theKeyName, binding, getPartitionTTL(), Cache.Visibility.ALL, false);
             // add the binding's cache key name to the bindingKeyIndex
             addBindingToKeyIndex(binding);
+            //System.debug('Adding binding for hash => ' + theKeyName + ' && developerName => ' + binding.developerName + ' && object => ' + binding.bindingObject);
         }
     }
 
     public list<di_Binding> retrieveBindings(String developerName, Schema.SObjectType bindingSObjectType)
-    {
+    {   
         list<di_Binding> bindings = new list<di_Binding>();
 
         if ( isStoringBindingInPlatformCache() )
         {
-            System.debug('developerName == ' + developerName + ' -- bindingSObjectType == ' + bindingSObjectType);
+            //System.debug('Retrieving from Cache Key => ' + developerName + ' && Cache Key Index => ' + bindingSObjectType);
 
             Map<Schema.SObjectType, Set<String>> keyIndexBySObjectTypeMap = getCacheKeyIndexMap().get(developerName.toLowerCase().trim());
             if ( keyIndexBySObjectTypeMap != null )
@@ -150,5 +175,18 @@ public with sharing class di_PlatformCache
         }
            
         return bindings;
+    }
+
+    public static void clearCachedBindings() {
+        String partitionKey = getPartitionName();
+        Cache.OrgPartition partition = getPartition();
+        // clear current bindings
+        for (String key : partition.getKeys() ) {
+            try {
+                partition.remove(key);
+            } catch (Exception ex) {
+                System.debug('XX]> Unable to remove Platform Cache partition [' + partitionKey + '] key [' + key + ']');
+            }
+        }
     }
 }


### PR DESCRIPTION
Changes made:
* di_PlatformCache class has new static method `clearCachedBindings`.
* minor adjustments to `getPartitionName()` and `getPartition()` methods to support `clearCachedBindings`.
* minor change to constructKeyName(Schema.SObjectType, String) method
    to ensure that the key is generate only once.  The usage of the hashcode()
    method can be expensive.

Non-related bug fix.  Change made to `getCacheKeyIndexMap()` method.
    Specifically, the call to the partition to get the cacheKeyIndexMap is now
    wrapped in a try/catch as it has been observed on one occasion that the
    cacheKeyIndexMap can become corrupt.  If this were to occur again, the
    index map would return empty and force a reload of all bindings to cache.