### PR TITLE
Fixes issue #50

### DIFF
--- a/force-di/main/classes/di_Binding.cls
+++ b/force-di/main/classes/di_Binding.cls
@@ -295,7 +295,9 @@ public abstract class di_Binding implements Comparable {
         {
             list<di_Binding> matchedBindings = di_PlatformCache.getInstance().retrieveBindings(this.developerName, this.bindingObject);
             
-            if ( bindingsAreRequired && matchedBindings.isEmpty() )
+            if ( ( bindingsAreRequired && matchedBindings.isEmpty() && di_PlatformCache.isStoringBindingInPlatformCache() ) 
+                || ! di_PlatformCache.isStoringBindingInPlatformCache()
+                )
             {
                 // Late resolve bindings to allow runtime module injection via set and add methods
                 loadBindings();

--- a/force-di/main/classes/di_PlatformCache.cls
+++ b/force-di/main/classes/di_PlatformCache.cls
@@ -28,7 +28,7 @@ public with sharing class di_PlatformCache
         return config;
     }
 
-    private Boolean isStoringBindingInPlatformCache()
+    public static Boolean isStoringBindingInPlatformCache()
     {
         return getConfig().UsePlatformCacheToStoreBindings__c == null ? false : getConfig().UsePlatformCacheToStoreBindings__c;
     }


### PR DESCRIPTION
Changes made:
di_PlatformCache.cls
* changed `isStoringBindingInPlatformCache()` method to be public and static. This will allow it to be available outside of the class

di_Binding.cls
* Changed the logic of the `di_Binding.Resolver.get()` method to also consider if platform cache is even active in the org.